### PR TITLE
fix exists - add missing object with "where" key

### DIFF
--- a/src/Prisma.ts
+++ b/src/Prisma.ts
@@ -74,7 +74,7 @@ export class Prisma extends Binding {
             this.delegate(
               'query',
               pluralFieldName,
-              args,
+              { where: args },
               buildExistsInfo(pluralFieldName, this.schema),
             ).then(res => res.length > 0),
         }


### PR DESCRIPTION
`exists` in `v2.0` is not working anymore like in previous versions. Now it needs additional wrapping object as argument.
```
// now:
prisma.exists.Post({
  where: {
    id: 'abc'
  }
})
// in v1.x :
prisma.exists.Post({
  id: 'abc'
})
```

Current version doesn't fit to documentation or generated types.

Here is breaking commit (with line that included `where`): 
https://github.com/graphcool/prisma-binding/commit/43d296036a990ce75ce0a80d30dd12ce715d140a#diff-d58fbe517034c5956a0e6d5d20cd5f42L105 